### PR TITLE
Fix Doctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This crate provides routines for searching **discontiguous strings** for matches
 
 It is intended as a prototype for upstream support for "streaming regex". The cursor based API in this crate is very similar to the API already exposed by `regex`/`regex-automata`. To that end a generic `Cursor` trait is provided that collections can implement.
 
-A sketch of the cursor API is shown below. The string is yielded in multiple byte chunks. Calling advance moves the cursor to the next chunk. Calling backtrack moves the cursor a chunk back. Backtracking is required by this create. That makes it unsuitable for searching fully unbuffered streams like bytes send over a TCP connection. 
+A sketch of the cursor API is shown below. The string is yielded in multiple byte chunks. Calling advance moves the cursor to the next chunk. Calling backtrack moves the cursor a chunk back. Backtracking is required by this crate. That makes it unsuitable for searching fully unbuffered streams like bytes send over a TCP connection. 
 
 ``` rust
 pub trait Cursor {

--- a/src/input.rs
+++ b/src/input.rs
@@ -55,9 +55,9 @@ impl<C: Cursor> Input<C> {
     /// # Example
     ///
     /// ```
-    /// use ropey_regex::Input;
+    /// use regex_cursor::Input;
     ///
-    /// let input = Input::new("foobar".into());
+    /// let input = Input::new("foobar");
     /// assert_eq!(b"foobar", input.chunk());
     /// ```
     #[cfg_attr(feature = "perf-inline", inline(always))]
@@ -70,9 +70,9 @@ impl<C: Cursor> Input<C> {
     /// # Example
     ///
     /// ```
-    /// use ropey_regex::Input;
+    /// use regex_cursor::Input;
     ///
-    /// let input = Input::new("foobar".into());
+    /// let input = Input::new("foobar");
     /// assert_eq!(b"foobar", input.chunk());
     /// ```
     #[cfg_attr(feature = "perf-inline", inline(always))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ collections can implement.
 A sketch of the cursor API is shown below. The string is yielded in multiple
 byte chunks. Calling advance moves the cursor to the next chunk. Calling
 backtrack moves the cursor a chunk back. Backtracking is required by this
-create. That makes it unsuitable for searching fully unbuffered streams like
+crate. That makes it unsuitable for searching fully unbuffered streams like
 bytes send over a TCP connection.
 
 ```rust_ignore
@@ -23,7 +23,7 @@ pub trait Cursor {
 }
 ```
 
-Working on this crate showed met hat regex backtracks a lot more than expected
+Working on this crate showed me that regex backtracks a lot more than expected
 with most functionality fundamentally requiring backtracking. For network
 usecases that do not buffer their input the primary usecase would likely be
 detecting a match (without necessarily requiring the matched byte range).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ backtrack moves the cursor a chunk back. Backtracking is required by this
 create. That makes it unsuitable for searching fully unbuffered streams like
 bytes send over a TCP connection.
 
-```
+```rust_ignore
 pub trait Cursor {
    fn chunk(&self) -> &[u8] { .. }
     fn advance(&mut self) -> bool { .. }


### PR DESCRIPTION
This fixes a typo, and some compilation failures when doc tests are run,

Since the ropey stuff now looked to be feature gated, I just removed the 'into()' call, so it's an `Input<&str>`.
Perhaps that is not the right thing, but seemed easiest way?