### PR TITLE
Add missing URLs to links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # regex-cursor
 
 
-This crate provides routines for searching **discontiguous strings** for matches of a [regular expression] (aka "regex"). It is based on [regex-automata] and most of the code is adapted from the various crates in the [regex](https://github.com/rust-lang/regex) repository.
+This crate provides routines for searching **discontiguous strings** for matches of a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) (aka "regex"). It is based on [regex-automata](https://crates.io/crates/regex-automata) and most of the code is adapted from the various crates in the [regex](https://github.com/rust-lang/regex) repository.
 
 It is intended as a prototype for upstream support for "streaming regex". The cursor based API in this crate is very similar to the API already exposed by `regex`/`regex-automata`. To that end a generic `Cursor` trait is provided that collections can implement.
 


### PR DESCRIPTION
The `[square brackets]` around these words made it look like you meant to put links there but forgot. For the links, I chose the URLs I think you most likely meant.